### PR TITLE
Fix Track 4–6 hermetic-egress footguns (issues 90–97)

### DIFF
--- a/automation/gitops/components/gitea/files/seed/overlay-python/tekton/pipeline.yaml
+++ b/automation/gitops/components/gitea/files/seed/overlay-python/tekton/pipeline.yaml
@@ -124,7 +124,7 @@ spec:
           value: "false"
 
     - name: syft-sbom-rhtpa
-      runAfter: [acs-image-check]
+      runAfter: [openshift-build]
       taskRef:
         resolver: cluster
         params:
@@ -142,6 +142,8 @@ spec:
       params:
         - name: image
           value: $(params.image-url)
+        - name: rhtpa-url
+          value: ""
 
     - name: cosign-sign-keyless
       runAfter: [syft-sbom-rhtpa]

--- a/automation/gitops/components/gitea/files/seed/overlay-python/tekton/pipelinerun.yaml
+++ b/automation/gitops/components/gitea/files/seed/overlay-python/tekton/pipelinerun.yaml
@@ -22,11 +22,11 @@ spec:
     - name: buildconfig-name
       value: fastapi-lw-poc
     - name: cosign-fulcio-url
-      value: https://fulcio-server-trusted-artifact-signer.apps.<domain>
+      value: http://fulcio-server.trusted-artifact-signer.svc
     - name: cosign-rekor-url
-      value: https://rekor-server-trusted-artifact-signer.apps.<domain>
+      value: http://rekor-server.trusted-artifact-signer.svc
     - name: cosign-tuf-url
-      value: https://tuf-trusted-artifact-signer.apps.<domain>
+      value: http://tuf.trusted-artifact-signer.svc
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/automation/gitops/components/gitea/files/seed/overlay/tekton/pipeline.yaml
+++ b/automation/gitops/components/gitea/files/seed/overlay/tekton/pipeline.yaml
@@ -126,7 +126,7 @@ spec:
           value: "false"
 
     - name: syft-sbom-rhtpa
-      runAfter: [acs-image-check]
+      runAfter: [openshift-build]
       taskRef:
         resolver: cluster
         params:
@@ -144,6 +144,8 @@ spec:
       params:
         - name: image
           value: $(params.image-url)
+        - name: rhtpa-url
+          value: ""
 
     - name: cosign-sign-keyless
       runAfter: [syft-sbom-rhtpa]

--- a/automation/gitops/components/gitea/files/seed/overlay/tekton/pipelinerun.yaml
+++ b/automation/gitops/components/gitea/files/seed/overlay/tekton/pipelinerun.yaml
@@ -1,6 +1,9 @@
 # Example PipelineRun — edit repo-url / image-url / Fulcio / Rekor for your claim.
 # repo-url after 4.3: demo-userinfo-gitea → student_repo_internal_url
 # (http://gitea.gitea.svc:3000/… — HTTPS Route is blocked by build-egress).
+# Fulcio / Rekor / TUF after 4.3: demo-userinfo-rhtas → fulcio_internal_url /
+# rekor_internal_url / tuf_internal_url (in-cluster Services). Route hints
+# (fulcio_url_hint) are for Showroom verify only — PipelineRuns cannot reach them.
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
@@ -20,12 +23,13 @@ spec:
       value: image-registry.openshift-image-registry.svc:5000/<lab-namespace>/spring-boot-lw-poc:latest
     - name: buildconfig-name
       value: spring-boot-lw-poc
+    # After 4.3 fill from demo-userinfo-rhtas fulcio_internal_url / rekor_internal_url / tuf_internal_url
     - name: cosign-fulcio-url
-      value: https://fulcio-server-trusted-artifact-signer.apps.<domain>
+      value: http://fulcio-server.trusted-artifact-signer.svc
     - name: cosign-rekor-url
-      value: https://rekor-server-trusted-artifact-signer.apps.<domain>
+      value: http://rekor-server.trusted-artifact-signer.svc
     - name: cosign-tuf-url
-      value: https://tuf-trusted-artifact-signer.apps.<domain>
+      value: http://tuf.trusted-artifact-signer.svc
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/automation/gitops/components/lightwell-repo/templates/_helpers.tpl
+++ b/automation/gitops/components/lightwell-repo/templates/_helpers.tpl
@@ -45,3 +45,8 @@ registry-{{ .Values.lightwellRepo.namespace }}.apps.cluster.example.com
 {{- define "lightwell-repo.registryUrl" -}}
 https://{{ include "lightwell-repo.registryHost" . }}
 {{- end -}}
+
+{{/* In-cluster Docker Registry API (Service). Route dest_registry_host is blocked after 4.3. */}}
+{{- define "lightwell-repo.registryInternalHost" -}}
+{{ .Values.nexus.name }}.{{ .Values.lightwellRepo.namespace }}.svc:{{ .Values.nexus.docker.port }}
+{{- end -}}

--- a/automation/gitops/components/lightwell-repo/templates/userinfo.yaml
+++ b/automation/gitops/components/lightwell-repo/templates/userinfo.yaml
@@ -3,6 +3,7 @@
 {{- $nexusInternalUrl := include "lightwell-repo.nexusInternalUrl" . }}
 {{- $regUrl := include "lightwell-repo.registryUrl" . }}
 {{- $regHost := include "lightwell-repo.registryHost" . }}
+{{- $regInternalHost := include "lightwell-repo.registryInternalHost" . }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -55,6 +56,7 @@ data:
   cluster_api_url: {{ .Values.deployer.apiUrl | quote }}
 {{- if .Values.channels.dockerMirror.enabled }}
   dest_registry_host: {{ $regHost | quote }}
+  dest_registry_internal_host: {{ $regInternalHost | quote }}
   dest_registry_url: {{ $regUrl | quote }}
   dest_registry_docker: {{ printf "docker://%s" $regHost | quote }}
   dest_registry_repo: {{ .Values.channels.dockerMirror.name | quote }}

--- a/automation/gitops/components/networkpolicy/templates/userinfo.yaml
+++ b/automation/gitops/components/networkpolicy/templates/userinfo.yaml
@@ -30,6 +30,15 @@ data:
   allow_nexus_docker_port: {{ .Values.allow.nexusDockerPort | quote }}
   allow_gitea_namespace: {{ .Values.allow.giteaNamespace | quote }}
   allow_gitea_port: {{ .Values.allow.giteaPort | quote }}
+  allow_stackrox_namespace: {{ .Values.allow.stackroxNamespace | quote }}
+  allow_stackrox_port: {{ .Values.allow.stackroxPort | quote }}
+  allow_tas_namespace: {{ .Values.allow.tasNamespace | quote }}
+  allow_tas_tuf_port: {{ .Values.allow.tasTufPort | quote }}
+  allow_tas_fulcio_port: {{ .Values.allow.tasFulcioPort | quote }}
+  allow_tas_fulcio_grpc_port: {{ .Values.allow.tasFulcioGrpcPort | quote }}
+  allow_tas_rekor_port: {{ .Values.allow.tasRekorPort | quote }}
+  allow_tpa_namespace: {{ .Values.allow.tpaNamespace | quote }}
+  allow_tpa_port: {{ .Values.allow.tpaPort | quote }}
   allow_kube_api_namespace: default
   allow_kube_api_svc: kubernetes
   do_not_copy: example-hermetic-egress.yaml

--- a/automation/gitops/components/networkpolicy/values.yaml
+++ b/automation/gitops/components/networkpolicy/values.yaml
@@ -33,6 +33,17 @@ allow:
   nexusDockerPort: 5000
   giteaNamespace: gitea
   giteaPort: 3000
+  # OVN matches NetworkPolicy egress ports to *pod* ports, not Service ports.
+  # Central Service 443 → 8443; TUF 80 → 8080; Fulcio 80 → 5555; Rekor 80 → 3000; TPA 443 → 8080.
+  stackroxNamespace: stackrox
+  stackroxPort: 8443
+  tasNamespace: trusted-artifact-signer
+  tasTufPort: 8080
+  tasFulcioPort: 5555
+  tasFulcioGrpcPort: 5554
+  tasRekorPort: 3000
+  tpaNamespace: trusted-profile-analyzer
+  tpaPort: 8080
 
 userInfo:
   enabled: true
@@ -40,7 +51,9 @@ userInfo:
   instructions: >-
     Track 4.3: tighten NetworkPolicy build-egress in lw-poc-build to deny-egress
     with DNS + internal registry + Nexus + in-cluster Gitea + kube API (so 4.4
-    clone and oc start-build work). Seed is too open. Track 6: app-operate on lw-poc-staging and lw-poc-prod stays operate
+    clone and oc start-build work) plus stackrox / RHTAS / TPA pod ports (so ACS,
+    keyless sign, and optional TPA upload work after Routes are blocked). Seed is
+    too open. Track 6: app-operate on lw-poc-staging and lw-poc-prod stays operate
     (seeded open). Do not merge the two Checks. Do not copy the worked example.
 
 deployer:

--- a/automation/gitops/components/pipelines/templates/prefetch-dependencies-docs.yaml
+++ b/automation/gitops/components/pipelines/templates/prefetch-dependencies-docs.yaml
@@ -31,7 +31,9 @@ data:
     openshift-build. Point settings.xml at in-cluster Nexus with mirrorOf *
     (the seed still lists repo.maven.apache.org). Prefetch writes
     {{ .Values.prefetchDependencies.prefetchDir }} into the source workspace
-    so Binary BuildConfig can consume it. Dockerfile mvn -o is Track 4 content
+    so Binary BuildConfig can consume it. Dockerfile must COPY that directory
+    (and settings.xml if using -s) into the build stage — workspace files are
+    only in the Docker context until COPY. Dockerfile mvn -o is Track 4 content
     (V2-34) — do not copy example-pipeline-snippet.yaml.
 
     Image build stays OpenShift BuildConfig (no Buildah).

--- a/automation/gitops/components/rhacs/files/mint-ci-token.sh
+++ b/automation/gitops/components/rhacs/files/mint-ci-token.sh
@@ -32,7 +32,7 @@ if ! oc -n "${NAMESPACE}" get secret central-htpasswd >/dev/null 2>&1; then
   exit 1
 fi
 
-ENDPOINT="${CENTRAL_HOST}:443"
+ENDPOINT="${PIPELINE_ENDPOINT:-central.${NAMESPACE}.svc:443}"
 if [[ -z "${ENDPOINT}" || "${ENDPOINT}" == ":443" ]]; then
   ENDPOINT="${FALLBACK_ENDPOINT}"
 fi
@@ -62,7 +62,7 @@ else
       --from-literal=rox-api-endpoint="${ENDPOINT}" \
       --from-literal=rox-api-token="${TOKEN}"
   fi
-  echo "Patched Secret ${NAMESPACE}/${SECRET_NAME} (endpoint + token)."
+  echo "Patched Secret ${NAMESPACE}/${SECRET_NAME} (in-cluster endpoint ${ENDPOINT} + token)."
 fi
 
 # Tekton cluster-resolves the Task from stackrox but mounts secrets in the TaskRun ns.

--- a/automation/gitops/components/rhacs/templates/_helpers.tpl
+++ b/automation/gitops/components/rhacs/templates/_helpers.tpl
@@ -27,3 +27,8 @@ https://{{ include "rhacs.centralHost" . }}
 {{- define "rhacs.centralEndpoint" -}}
 {{ include "rhacs.centralHost" . }}:443
 {{- end -}}
+
+{{/* In-cluster Central for pipeline pods after 4.3 (Route is the ingress VIP). */}}
+{{- define "rhacs.centralInternalEndpoint" -}}
+central.{{ .Values.rhacs.namespace }}.svc:443
+{{- end -}}

--- a/automation/gitops/components/rhacs/templates/acs-image-check-task.yaml
+++ b/automation/gitops/components/rhacs/templates/acs-image-check-task.yaml
@@ -100,9 +100,14 @@ spec:
           curl_insecure="--insecure"
         fi
 
-        curl ${curl_insecure} -s -L -H "Authorization: Bearer ${ROX_API_TOKEN}" \
+        if ! curl ${curl_insecure} -fsS -L --max-time 20 -H "Authorization: Bearer ${ROX_API_TOKEN}" \
           "https://${ROX_CENTRAL_ENDPOINT}/api/cli/download/roxctl-linux" \
-          --output ./roxctl
+          --output ./roxctl; then
+          skip_exit "roxctl download failed from ${ROX_CENTRAL_ENDPOINT}"
+        fi
+        if [[ ! -s ./roxctl ]]; then
+          skip_exit "roxctl download empty from ${ROX_CENTRAL_ENDPOINT}"
+        fi
         chmod +x ./roxctl
 
         echo "roxctl image check --image=${PARAM_IMAGE}"

--- a/automation/gitops/components/rhacs/templates/ci-secret-placeholder.yaml
+++ b/automation/gitops/components/rhacs/templates/ci-secret-placeholder.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rhacs.enabled .Values.pipelineHooks.enabled .Values.pipelineHooks.createSecretPlaceholder }}
-{{- $endpoint := include "rhacs.centralEndpoint" . }}
+{{- $endpoint := include "rhacs.centralInternalEndpoint" . }}
 ---
 # Placeholder for CI credentials used by Tekton Task acs-image-check.
 # After Central is Ready, create an API token with CI permissions and patch this Secret:

--- a/automation/gitops/components/rhacs/templates/ci-token-job.yaml
+++ b/automation/gitops/components/rhacs/templates/ci-token-job.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.rhacs.enabled .Values.pipelineHooks.enabled .Values.pipelineHooks.ciTokenJob.enabled }}
 {{- $endpoint := include "rhacs.centralEndpoint" . }}
+{{- $pipelineEndpoint := include "rhacs.centralInternalEndpoint" . }}
 ---
 # Mint Central CI token, copy it into the learner build namespace (Tekton mounts
 # secrets from the TaskRun ns), and register the internal registry so roxctl can
@@ -44,6 +45,8 @@ spec:
               value: {{ .Values.pipelineHooks.ciTokenJob.waitSeconds | quote }}
             - name: FALLBACK_ENDPOINT
               value: {{ $endpoint | quote }}
+            - name: PIPELINE_ENDPOINT
+              value: {{ $pipelineEndpoint | quote }}
             - name: BUILD_NAMESPACE
               value: {{ .Values.pipelineHooks.buildNamespace | quote }}
             - name: REGISTRY_INTEGRATION

--- a/automation/gitops/components/rhacs/templates/lightwell-policy-pipeline.yaml
+++ b/automation/gitops/components/rhacs/templates/lightwell-policy-pipeline.yaml
@@ -91,7 +91,7 @@ spec:
           value: {{ .Values.pipelineHooks.failOnSkipped | quote }}
 
     - name: syft-sbom-rhtpa
-      runAfter: [acs-image-check]
+      runAfter: [lightwell-dep-gate]
       taskRef:
         kind: Task
         name: {{ .Values.pipelineHooks.sbom.taskName }}

--- a/automation/gitops/components/rhacs/templates/lightwell-python-policy-pipeline.yaml
+++ b/automation/gitops/components/rhacs/templates/lightwell-python-policy-pipeline.yaml
@@ -91,7 +91,7 @@ spec:
           value: {{ .Values.pipelineHooks.failOnSkipped | quote }}
 
     - name: syft-sbom-rhtpa
-      runAfter: [acs-image-check]
+      runAfter: [lightwell-python-dep-gate]
       taskRef:
         kind: Task
         name: {{ .Values.pipelineHooks.sbom.taskName }}

--- a/automation/gitops/components/rhacs/templates/syft-sbom-task.yaml
+++ b/automation/gitops/components/rhacs/templates/syft-sbom-task.yaml
@@ -186,8 +186,8 @@ spec:
           echo "WARN: ${OUT} missing — skip persist"
           exit 0
         fi
+        oc delete configmap "${PERSIST_CM}" --ignore-not-found
         oc create configmap "${PERSIST_CM}" \
-          --from-file=sbom.cyclonedx.json="${OUT}" \
-          --dry-run=client -o yaml | oc apply -f -
+          --from-file=sbom.cyclonedx.json="${OUT}"
         echo "Persisted ConfigMap ${PERSIST_CM} for Track 7.1 (emptyDir does not survive pod completion)"
 {{- end }}

--- a/automation/gitops/components/rhacs/templates/userinfo.yaml
+++ b/automation/gitops/components/rhacs/templates/userinfo.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.rhacs.enabled .Values.userInfo.enabled }}
 {{- $centralUrl := include "rhacs.centralUrl" . }}
 {{- $endpoint := include "rhacs.centralEndpoint" . }}
+{{- $internalEndpoint := include "rhacs.centralInternalEndpoint" . }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -21,6 +22,7 @@ data:
   central_name: {{ .Values.central.name | quote }}
   central_url: {{ $centralUrl | quote }}
   central_endpoint: {{ $endpoint | quote }}
+  central_internal_endpoint: {{ $internalEndpoint | quote }}
   pipeline_task: {{ .Values.pipelineHooks.taskName | quote }}
   cluster_domain: {{ .Values.deployer.domain | quote }}
   cluster_api_url: {{ .Values.deployer.apiUrl | quote }}

--- a/automation/gitops/components/rhacs/values.yaml
+++ b/automation/gitops/components/rhacs/values.yaml
@@ -62,7 +62,7 @@ pipelineHooks:
   enabled: true
   taskName: acs-image-check
   # Secret keys expected by the Task (create after Central is Ready — do not commit tokens)
-  #   rox-api-endpoint: central-stackrox.apps.<domain>:443
+  #   rox-api-endpoint: central.stackrox.svc:443 (in-cluster; Route is blocked after 4.3)
   #   rox-api-token: <CI API token from Central>
   secretName: rhacs-ci-secrets
   createSecretPlaceholder: true

--- a/automation/gitops/components/rhdh/files/skeletons/lightwell-java-service/.tekton/pipeline.yaml
+++ b/automation/gitops/components/rhdh/files/skeletons/lightwell-java-service/.tekton/pipeline.yaml
@@ -116,7 +116,7 @@ spec:
           value: $(params.image-url)
 
     - name: syft-sbom-rhtpa
-      runAfter: [acs-image-check]
+      runAfter: [openshift-build]
       taskRef:
         resolver: cluster
         params:
@@ -134,6 +134,8 @@ spec:
       params:
         - name: image
           value: $(params.image-url)
+        - name: rhtpa-url
+          value: ""
 
     - name: cosign-sign-keyless
       runAfter: [syft-sbom-rhtpa]

--- a/automation/gitops/components/rhdh/files/skeletons/lightwell-java-service/.tekton/pipelinerun.yaml
+++ b/automation/gitops/components/rhdh/files/skeletons/lightwell-java-service/.tekton/pipelinerun.yaml
@@ -18,11 +18,11 @@ spec:
     - name: buildconfig-name
       value: ${{ values.name }}
     - name: cosign-fulcio-url
-      value: https://fulcio-server-trusted-artifact-signer.apps.<domain>
+      value: http://fulcio-server.trusted-artifact-signer.svc
     - name: cosign-rekor-url
-      value: https://rekor-server-trusted-artifact-signer.apps.<domain>
+      value: http://rekor-server.trusted-artifact-signer.svc
     - name: cosign-tuf-url
-      value: https://tuf-trusted-artifact-signer.apps.<domain>
+      value: http://tuf.trusted-artifact-signer.svc
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/automation/gitops/components/rhdh/files/skeletons/lightwell-python-service/.tekton/pipeline.yaml
+++ b/automation/gitops/components/rhdh/files/skeletons/lightwell-python-service/.tekton/pipeline.yaml
@@ -118,7 +118,7 @@ spec:
           value: $(params.image-url)
 
     - name: syft-sbom-rhtpa
-      runAfter: [acs-image-check]
+      runAfter: [openshift-build]
       taskRef:
         resolver: cluster
         params:
@@ -136,6 +136,8 @@ spec:
       params:
         - name: image
           value: $(params.image-url)
+        - name: rhtpa-url
+          value: ""
 
     - name: cosign-sign-keyless
       runAfter: [syft-sbom-rhtpa]

--- a/automation/gitops/components/rhdh/files/skeletons/lightwell-python-service/.tekton/pipelinerun.yaml
+++ b/automation/gitops/components/rhdh/files/skeletons/lightwell-python-service/.tekton/pipelinerun.yaml
@@ -21,11 +21,11 @@ spec:
     - name: buildconfig-name
       value: ${{ values.name }}
     - name: cosign-fulcio-url
-      value: https://fulcio-server-trusted-artifact-signer.apps.<domain>
+      value: http://fulcio-server.trusted-artifact-signer.svc
     - name: cosign-rekor-url
-      value: https://rekor-server-trusted-artifact-signer.apps.<domain>
+      value: http://rekor-server.trusted-artifact-signer.svc
     - name: cosign-tuf-url
-      value: https://tuf-trusted-artifact-signer.apps.<domain>
+      value: http://tuf.trusted-artifact-signer.svc
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/automation/gitops/components/rhtas/templates/userinfo.yaml
+++ b/automation/gitops/components/rhtas/templates/userinfo.yaml
@@ -28,5 +28,9 @@ data:
   fulcio_url_hint: {{ printf "https://fulcio-server-%s.%s" .Values.rhtas.namespace .Values.deployer.domain | quote }}
   rekor_url_hint: {{ printf "https://rekor-server-%s.%s" .Values.rhtas.namespace .Values.deployer.domain | quote }}
   tuf_url_hint: {{ printf "https://tuf-%s.%s" .Values.rhtas.namespace .Values.deployer.domain | quote }}
+  # PipelineRun after 4.3: Routes time out (ingress VIP). Use in-cluster Services.
+  fulcio_internal_url: "http://fulcio-server.{{ .Values.rhtas.namespace }}.svc"
+  rekor_internal_url: "http://rekor-server.{{ .Values.rhtas.namespace }}.svc"
+  tuf_internal_url: "http://tuf.{{ .Values.rhtas.namespace }}.svc"
   cosign_image: "registry.redhat.io/rhtas/cosign-rhel9:1.3.0"
 {{- end }}

--- a/automation/gitops/components/validate-jobs/files/check-08.sh
+++ b/automation/gitops/components/validate-jobs/files/check-08.sh
@@ -10,6 +10,11 @@ from_lines="$(printf '%s\n' "$df" | grep -E '^FROM ' || true)"
 deny_contains "active Dockerfile FROM" "$from_lines" "registry.access.redhat.com"
 deny_contains "active Dockerfile FROM" "$from_lines" "registry.redhat.io"
 deny_contains "active Dockerfile FROM" "$from_lines" "docker.io"
+dest="$(userinfo "$REPO_NS" "$REPO_USERINFO" dest_registry_host)"
+if [[ -n "$dest" ]]; then
+  deny_contains "active Dockerfile FROM (dest Route after 4.1)" "$from_lines" "$dest"
+fi
+require_contains "active Dockerfile FROM" "$from_lines" "image-registry.openshift-image-registry.svc"
 deny_contains "active Dockerfile" "$df" "curl "
 settings="$(gitea_raw "$org" "$repo" settings.xml)"
 deny_contains "${org}/${repo} settings.xml" "$settings" "repo.maven.apache.org"

--- a/automation/gitops/components/validate-jobs/files/check-09.sh
+++ b/automation/gitops/components/validate-jobs/files/check-09.sh
@@ -14,5 +14,6 @@ deny_contains "${org}/${repo} settings.xml" "$settings" "repo.maven.apache.org"
 df="$(gitea_raw "$org" "$repo" Dockerfile)"
 require_contains "${org}/${repo} Dockerfile" "$df" "mvn"
 require_contains "${org}/${repo} Dockerfile" "$df" "-o"
+require_contains "${org}/${repo} Dockerfile COPY .m2-offline" "$df" ".m2-offline"
 report_require_token hermeto_maps_to prefetch-dependencies prefetch-task
 pass "prefetch-dependencies is before openshift-build and Maven is offline."

--- a/automation/gitops/components/validate-jobs/files/check-10.sh
+++ b/automation/gitops/components/validate-jobs/files/check-10.sh
@@ -13,6 +13,12 @@ printf '%s\n' "$yaml" | grep -q 'image-registry' \
   || fail "build-egress must allow the in-cluster image registry."
 printf '%s\n' "$yaml" | grep -qE 'lightwell-repo|nexus' \
   || fail "build-egress must allow in-cluster Nexus (lightwell-repo)."
+printf '%s\n' "$yaml" | grep -q 'stackrox' \
+  || fail "build-egress must allow namespace stackrox (Central pod port 8443) so ACS can run after 4.3."
+printf '%s\n' "$yaml" | grep -qE 'port: 8443' \
+  || fail "build-egress must allow TCP 8443 to stackrox (Central Service 443 maps to pod 8443)."
+printf '%s\n' "$yaml" | grep -q 'trusted-artifact-signer' \
+  || fail "build-egress must allow trusted-artifact-signer (TUF/Fulcio/Rekor pod ports) so 5.1 can sign."
 deny_contains "build-egress" "$yaml" "8.8.8.8"
 if oc -n "$stage" get networkpolicy build-egress >/dev/null 2>&1; then
   fail "Do not copy build-egress onto ${stage}. Tighten it only in ${ns}."

--- a/automation/gitops/components/validate-jobs/files/check-12.sh
+++ b/automation/gitops/components/validate-jobs/files/check-12.sh
@@ -9,6 +9,7 @@ pr="$(gitea_raw "$org" "$repo" .tekton/pipelinerun.yaml)"
 deny_contains "${org}/${repo} .tekton/pipelinerun.yaml" "$pr" "STUDENT_REPO_URL_PLACEHOLDER"
 deny_contains "${org}/${repo} .tekton/pipelinerun.yaml" "$pr" "apps.<domain>"
 deny_contains "${org}/${repo} .tekton/pipelinerun.yaml" "$pr" "<lab-namespace>"
+require_contains "${org}/${repo} .tekton/pipelinerun.yaml in-cluster RHTAS" "$pr" "trusted-artifact-signer.svc"
 taskrun_succeeded "$ns" cosign-sign-keyless
 digest="$(oc -n "$ns" get istag spring-boot-lw-poc:latest \
   -o jsonpath='{.image.dockerImageReference}' 2>/dev/null || true)"

--- a/automation/gitops/components/validate-jobs/files/check-13.sh
+++ b/automation/gitops/components/validate-jobs/files/check-13.sh
@@ -13,6 +13,10 @@ ident="$(cm_get "$ns" conforma-policy certificate-identity-regexp)"
 deny_contains "${ns}/conforma-policy identity" "$ident" "example.invalid"
 cve="$(cm_get "$ns" conforma-policy data.yaml)"
 deny_contains "${ns}/conforma-policy data.yaml" "$cve" "restrict_max_cve_score: 999"
+policy_yaml="$(cm_get "$ns" conforma-policy policy.yaml)"
+require_contains "${ns}/conforma-policy policy.yaml" "$policy_yaml" "attestation_signature_check"
+deny_contains "${ns}/conforma-policy policy.yaml still excludes everything" "$policy_yaml" 'exclude:
+            - "*"'
 git_pl="$(gitea_raw "$org" "$repo" .tekton/pipeline.yaml)"
 task_before "$git_pl" cosign-sign-keyless conforma-policy "${org}/${repo} .tekton/pipeline.yaml"
 live="$(pipeline_yaml "$ns" spring-boot-lw-poc-build-sign)"

--- a/content/modules/ROOT/pages/module-06-bind-base-deps.adoc
+++ b/content/modules/ROOT/pages/module-06-bind-base-deps.adoc
@@ -51,8 +51,9 @@ Expect runtime `FROM` `ubi9/openjdk-21-runtime` and a default `commons.lang3.ver
 [source,bash,role=execute]
 ----
 oc -n lightwell-repo get configmap demo-userinfo-lightwell-repo \
-  -o jsonpath='dest={.data.dest_registry_host}{"\n"}'
+  -o jsonpath='dest={.data.dest_registry_host}{"\n"}internal={.data.dest_registry_internal_host}{"\n"}'
 echo 'Dest image path is hi/openjdk — not dest_registry_repo (hummingbird-mirror).'
+echo '3.2 uses dest_registry_host (Route). 4.1 retargets runtime FROM to an internal ImageStream so 4.4 still works after 4.3.'
 oc -n lightwell-repo logs job/oc-mirror-learner -c copy-signatures | grep '^DEST_PULLSPEC=' || true
 ----
 

--- a/content/modules/ROOT/pages/module-08-forbid-list.adoc
+++ b/content/modules/ROOT/pages/module-08-forbid-list.adoc
@@ -44,7 +44,7 @@ RUN curl -fsSL https://example.invalid/install.sh | sh
 
 == Your change: strip forbidden fetches; both FROM lines internal
 
-. While `build-egress` is still too open, import a JDK *builder* into `lw-poc-build` (do not invent a Hummingbird builder digest — use the UBI JDK stream already on the seed, copied *into* the internal registry):
+. While `build-egress` is still too open, import a JDK *builder* into `lw-poc-build` (do not invent a Hummingbird builder digest — use the UBI JDK stream already on the seed, copied *into* the internal registry). Import dest Hummingbird the same way — 3.2's runtime `FROM` is the Nexus Docker **Route**, which 4.3 blocks:
 
 [source,bash,role=execute]
 ----
@@ -52,9 +52,15 @@ BUILD_NS="$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.st
 oc -n "${BUILD_NS}" import-image openjdk-21-builder \
   --from=registry.access.redhat.com/ubi9/openjdk-21:1.21 \
   --confirm
+DEST="$(oc -n lightwell-repo logs job/oc-mirror-learner -c copy-signatures | grep '^DEST_PULLSPEC=' | cut -d= -f2-)"
+echo "DEST=${DEST}"
+oc -n "${BUILD_NS}" import-image hummingbird-openjdk \
+  --from="${DEST}" --confirm --insecure=true
+oc -n "${BUILD_NS}" get istag hummingbird-openjdk:latest \
+  -o jsonpath='{.image.dockerImageReference}{"\n"}'
 ----
 
-. Point the Dockerfile *build* `FROM` at that ImageStream (internal registry). Runtime `FROM` stays the dest Hummingbird digest from 3.2. No `registry.access.redhat.com` on active `FROM` lines.
+. Point the Dockerfile *build* `FROM` at ImageStream `openjdk-21-builder` (internal registry). Point *runtime* `FROM` at ImageStream `hummingbird-openjdk` using the dest digest from 1.2 / 3.2 (`image-registry.openshift-image-registry.svc:5000/${BUILD_NS}/hummingbird-openjdk@sha256:…`). Do not leave `dest_registry_host` (the Nexus Docker Route) on an active `FROM` line. No `registry.access.redhat.com` on active `FROM` lines.
 
 . In `settings.xml`, remove `repo.maven.apache.org` from the Lightwell profiles. Point remotes at the *in-cluster* Nexus service (`nexus_internal_url` from userinfo — `http://nexus.lightwell-repo.svc:8081`), not the HTTPS Route. Add a `<mirror>` with `mirrorOf` `*` (or `external:*`) whose URL is `${nexus_internal_url}/repository/maven-public/`. Seeded `maven-public` includes Validated + Remediated so `.rhlw-*` pins resolve. 4.3 will block the Nexus Route from `lw-poc-build`; the service URL keeps working.
 
@@ -78,7 +84,7 @@ git show HEAD:settings.xml | grep -E 'repo.maven.apache.org|lightwell-repo' || t
 test -f Dockerfile.known-bad && echo 'known-bad fixture present'
 ----
 
-Pass when active `Dockerfile` / `settings.xml` have no public `FROM`, no Central, no `curl` installers — and `Dockerfile.known-bad` still exists.
+Pass when active `Dockerfile` / `settings.xml` have no public `FROM`, no dest-registry Route, no Central, no `curl` installers — and `Dockerfile.known-bad` still exists. Both `FROM` lines use the internal registry.
 
 :report-name: report-08-forbid-list
 :report-key: hermetic_starts

--- a/content/modules/ROOT/pages/module-09-prefetch.adoc
+++ b/content/modules/ROOT/pages/module-09-prefetch.adoc
@@ -55,7 +55,16 @@ Named `hermeto`, uses `pip`, and `runAfter: [acs-image-check]` (too late). Paste
 
 . In Gitea `.tekton/pipeline.yaml` on `lw-student/spring-boot-lw-poc`, insert a task *after* `lightwell-dep-gate` and *before* `openshift-build`. Use cluster resolver, `name: prefetch-dependencies`, `namespace: lightwell-tasks`. Change `openshift-build` `runAfter` to include prefetch.
 
-. Prefetch writes `.m2-offline` into the source workspace. Switch the Dockerfile `RUN mvn … package` to offline, for example `-o -Dmaven.repo.local=.m2-offline` (exact flags must match the Task’s prefetch dir).
+. Prefetch writes `.m2-offline` into the source workspace. Binary `oc start-build --from-dir` only puts that directory in the Docker **context**. `COPY` it (and `settings.xml` if you pass `-s`) into the build stage, then switch `RUN mvn … package` to offline. Paths must match the Task’s prefetch dir (userinfo `prefetch_dir`, default `.m2-offline`) and the Dockerfile `WORKDIR`:
+
+[source,dockerfile]
+----
+COPY pom.xml ./
+COPY src ./src
+COPY settings.xml ./
+COPY .m2-offline ./.m2-offline
+RUN mvn -B -o -s settings.xml -Dmaven.repo.local=.m2-offline -DskipTests package
+----
 
 . Commit and push. Apply the Pipeline (not yet the successful 4.4 run) in `lw-poc-build` if it is not applied:
 
@@ -78,9 +87,10 @@ oc -n "${BUILD_NS}" get pipeline spring-boot-lw-poc-build-sign -o yaml | grep -A
 cd /tmp/spring-boot-lw-poc
 git show HEAD:settings.xml | grep repo.maven.apache.org && echo 'STILL HAS CENTRAL' || echo 'Central gone'
 git show HEAD:Dockerfile | grep -E 'mvn.*-o'
+git show HEAD:Dockerfile | grep -E 'COPY .*m2-offline'
 ----
 
-Pass when the live Pipeline includes `prefetch-dependencies` before `openshift-build`, settings have no Central, and the Dockerfile uses `mvn -o`. Empty prefetch dir / undeclared deps fail later on `mvn -o`.
+Pass when the live Pipeline includes `prefetch-dependencies` before `openshift-build`, settings have no Central, and the Dockerfile `COPY`s `.m2-offline` and uses `mvn -o`. Empty prefetch dir / undeclared deps fail later on `mvn -o`.
 
 :report-name: report-09-prefetch
 :report-key: hermeto_maps_to

--- a/content/modules/ROOT/pages/module-10-build-networkpolicy.adoc
+++ b/content/modules/ROOT/pages/module-10-build-networkpolicy.adoc
@@ -55,13 +55,16 @@ spec:
             cidr: 8.8.8.8/32
 ----
 
-Allow-list (from userinfo keys — do not invent CIDRs except the kube API ClusterIP you discover below):
+Allow-list (from userinfo keys — do not invent CIDRs except the kube API ClusterIP you discover below). OVN matches egress **ports** to the **pod** port after DNAT, not the Service port.
 
 * `openshift-dns` UDP (and TCP) port `5353`
 * `openshift-image-registry` TCP `5000`
 * `lightwell-repo` Nexus HTTP `8081` and Docker dest `5000`
 * `gitea` TCP `3000` (in-cluster clone — not the Gitea Route)
 * Kubernetes API: `default/kubernetes` ClusterIP TCP `443`, plus endpoint IPs TCP `6443` (hostNetwork masters; `namespaceSelector: default` does not match them)
+* `stackrox` TCP `8443` (Central Service is `443` → pod `8443` — `ports: [{port: 443}]` does not allow it)
+* `trusted-artifact-signer` TCP `8080` (TUF), `5555` (Fulcio HTTP), `5554` (Fulcio gRPC), `3000` (Rekor)
+* `trusted-profile-analyzer` TCP `8080` (TPA Service is `443` → pod `8080`)
 
 Discover the API addresses (they differ per claim):
 
@@ -73,7 +76,7 @@ oc -n default get endpoints kubernetes -o jsonpath='{.subsets[*].addresses[*].ip
 
 == Your change: tighten `build-egress`
 
-Replace the seed `egress: [ {} ]` with deny-by-default plus the destinations above (`namespaceSelector` on those namespaces, matching ports, plus `ipBlock` `/32` for the kube API ClusterIP and endpoint IPs). Do not add `registry.redhat.io` or a public CIDR. Do not rely on `namespaceSelector: openshift-ingress` for Routes — Route hostnames resolve to the ingress VIP, which that selector does not match. After 4.3, 4.4 must use in-cluster Gitea (`student_repo_internal_url`) and Nexus (`nexus_internal_url`), not HTTPS Routes.
+Replace the seed `egress: [ {} ]` with deny-by-default plus the destinations above (`namespaceSelector` on those namespaces, matching **pod** ports from userinfo, plus `ipBlock` `/32` for the kube API ClusterIP and endpoint IPs). Do not add `registry.redhat.io` or a public CIDR. Do not rely on `namespaceSelector: openshift-ingress` for Routes — Route hostnames resolve to the ingress VIP, which that selector does not match. After 4.3, 4.4 must use in-cluster Gitea (`student_repo_internal_url`) and Nexus (`nexus_internal_url`), not HTTPS Routes. Pipeline ACS / keyless sign / TPA need the stackrox / RHTAS / TPA pod ports — Service port 80 or 443 is not enough.
 
 [source,bash,role=execute]
 ----
@@ -87,7 +90,7 @@ oc -n lw-poc-staging get networkpolicy app-operate
 Pass when:
 
 * `build-egress` exists in `lw-poc-build`, is not allow-all egress, includes DNS + registry + Nexus
-* Extra allows for Gitea and kube API are expected so 4.4 can run
+* Extra allows for Gitea, kube API, stackrox `8443`, and RHTAS pod ports are expected so 4.4 / 5.1 can run
 * You did not copy it to `lw-poc-staging`
 * `app-operate` on staging/prod is still the operate seed
 
@@ -108,3 +111,4 @@ Honor system: 4.4 still opens. The Check grades the live NetworkPolicy, not a YA
 
 * Build hermetic ≠ app operate.
 * After this tighten, clone and Maven must use in-cluster service URLs, not Routes.
+* Pipeline Fulcio / Rekor / TUF must use `*_internal_url` from `demo-userinfo-rhtas`. Runtime `FROM` must already be the internal dest ImageStream from 4.1.

--- a/content/modules/ROOT/pages/module-11-build-sbom.adoc
+++ b/content/modules/ROOT/pages/module-11-build-sbom.adoc
@@ -48,7 +48,7 @@ oc -n "${BUILD_NS}" apply -f /tmp/spring-boot-lw-poc/.tekton/rbac.yaml
 oc -n "${BUILD_NS}" apply -f /tmp/spring-boot-lw-poc/.tekton/pipeline.yaml
 ----
 
-Edit `.tekton/pipelinerun.yaml`: replace `STUDENT_REPO_URL_PLACEHOLDER` with `student_repo_internal_url` (`http://gitea.gitea.svc:3000/…` — the HTTPS Route is blocked after 4.3), replace `<lab-namespace>` with `lw-poc-build`, and fill Fulcio/Rekor/TUF from `demo-userinfo-rhtas` if the run includes the sign task (placeholders fail). Then:
+Edit `.tekton/pipelinerun.yaml`: replace `STUDENT_REPO_URL_PLACEHOLDER` with `student_repo_internal_url` (`http://gitea.gitea.svc:3000/…` — the HTTPS Route is blocked after 4.3), replace `<lab-namespace>` with `lw-poc-build`, and fill Fulcio/Rekor/TUF from `demo-userinfo-rhtas` **`fulcio_internal_url` / `rekor_internal_url` / `tuf_internal_url`** (in-cluster Services). Route hints (`fulcio_url_hint`) fail after 4.3. Leave syft `rhtpa-url` empty — Track 7 uploads from Showroom. Then:
 
 [source,bash,role=execute]
 ----
@@ -73,7 +73,7 @@ oc -n "${BUILD_NS}" get pipelinerun
 oc -n "${BUILD_NS}" get tr -l tekton.dev/pipelineTask=syft-sbom-rhtpa
 ----
 
-Known-bad: patch the BuildConfig Dockerfile, start a binary build, then restore the good path. `oc start-build` has no `-DdockerfilePath`.
+Known-bad: patch the BuildConfig Dockerfile, start a binary build, then restore the good path. `oc start-build` has no `-DdockerfilePath`. The first `registry-1.docker.io` / `dial tcp …:443: i/o timeout` is the fail — press **Ctrl-C**. OpenShift retries that pull for many minutes; do not wait for `--follow` to exit. Then restore `dockerfilePath`.
 
 [source,bash,role=execute]
 ----
@@ -81,6 +81,7 @@ BUILD_NS="$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.st
 cd /tmp/spring-boot-lw-poc
 oc -n "${BUILD_NS}" patch bc spring-boot-lw-poc --type=json \
   -p '[{"op":"replace","path":"/spec/strategy/dockerStrategy/dockerfilePath","value":"Dockerfile.known-bad"}]'
+# Ctrl-C after the first registry-1.docker.io timeout — do not wait out retries.
 oc -n "${BUILD_NS}" start-build spring-boot-lw-poc --from-dir=. --follow || true
 oc -n "${BUILD_NS}" patch bc spring-boot-lw-poc --type=json \
   -p '[{"op":"replace","path":"/spec/strategy/dockerStrategy/dockerfilePath","value":"Dockerfile"}]'

--- a/content/modules/ROOT/pages/module-12-sign-keyless.adoc
+++ b/content/modules/ROOT/pages/module-12-sign-keyless.adoc
@@ -5,7 +5,7 @@
 
 Sign the *app* digest you built in xref:module-11-build-sbom.adoc[4.4] — not the Hummingbird base. This Check is *keyless* RHTAS (Fulcio, Rekor, TUF) plus `cosign verify` on *that* digest. Key-based sign + `--key` verify is a *second* Check (xref:module-14-disconnected-verify.adoc[5.3]). Do not treat keyless-only as Track 5 done.
 
-The seeded pipeline already has task `cosign-sign-keyless`. Placeholders in the PipelineRun (`apps.<domain>`) fail that task until you fill live Fulcio / Rekor / TUF URLs.
+The seeded pipeline already has task `cosign-sign-keyless`. Placeholders in the PipelineRun fail that task until you fill live **in-cluster** Fulcio / Rekor / TUF URLs (`fulcio_internal_url` and friends). Route hints (`fulcio_url_hint`) are for Showroom `cosign verify` only — the build namespace cannot reach them after 4.3.
 
 == Learning objectives
 
@@ -35,7 +35,7 @@ Keyless is the *connected* PoV path: the pipeline SA presents an OIDC token, Ful
 ----
 command -v cosign
 oc -n trusted-artifact-signer get configmap demo-userinfo-rhtas \
-  -o jsonpath='{.data.signing_model}{"\n"}{.data.fulcio_url_hint}{"\n"}{.data.rekor_url_hint}{"\n"}{.data.tuf_url_hint}{"\n"}'
+  -o jsonpath='{.data.signing_model}{"\n"}{.data.fulcio_internal_url}{"\n"}{.data.rekor_internal_url}{"\n"}{.data.tuf_internal_url}{"\n"}{.data.fulcio_url_hint}{"\n"}{.data.rekor_url_hint}{"\n"}{.data.tuf_url_hint}{"\n"}'
 oc -n trusted-artifact-signer get routes
 ----
 
@@ -54,7 +54,7 @@ cosign verify \
 
 == Your change: fill URLs; sign the app digest
 
-If 4.4 already ran `cosign-sign-keyless` to Succeeded, skip to verify. Otherwise edit `.tekton/pipelinerun.yaml` on `lw-student/spring-boot-lw-poc`: replace Fulcio / Rekor / TUF with the userinfo URLs, `STUDENT_REPO_URL_PLACEHOLDER` with `student_repo_internal_url` (in-cluster Gitea, not the HTTPS Route), and `<lab-namespace>` with `lw-poc-build`. Then create a new run:
+If 4.4 already ran `cosign-sign-keyless` to Succeeded, skip to verify. Otherwise edit `.tekton/pipelinerun.yaml` on `lw-student/spring-boot-lw-poc`: replace Fulcio / Rekor / TUF with `fulcio_internal_url` / `rekor_internal_url` / `tuf_internal_url` (not the HTTPS Route hints), `STUDENT_REPO_URL_PLACEHOLDER` with `student_repo_internal_url` (in-cluster Gitea, not the HTTPS Route), and `<lab-namespace>` with `lw-poc-build`. Then create a new run:
 
 [source,bash,role=execute]
 ----

--- a/content/modules/ROOT/pages/module-13-attest-conforma.adoc
+++ b/content/modules/ROOT/pages/module-13-attest-conforma.adoc
@@ -66,7 +66,18 @@ oc -n lightwell-tasks get configmap conforma-policy -o yaml \
   | oc apply -f -
 ----
 
-. On the *copy*, set `skip-image-sig-check` to `false`. Leave `skip-att-sig-check` `true` (no Chains attestation on this claim; `ec` 0.7 uses `--ignore-rekor`). Set `certificate-identity-regexp` to the same pipeline SA regexp you used in 5.1 (not `.*`, not a Hummingbird placeholder). Set the OIDC issuer regexp to `https://kubernetes.default.svc`. In `policy.yaml` / `data.yaml`, drop `exclude: *`, lower `restrict_max_cve_score` below 999, and pin `allowed_registry_prefixes` to the internal registry (`image-registry.openshift-image-registry.svc`).
+. On the *copy*, set `skip-image-sig-check` to `false`. Leave `skip-att-sig-check` `true` (no Chains attestation on this claim). Set `certificate-identity-regexp` to the same pipeline SA regexp you used in 5.1 (not `.*`, not a Hummingbird placeholder). Set the OIDC issuer regexp to `https://kubernetes.default.svc`. In `policy.yaml` / `data.yaml`, drop `exclude: *`, then **exclude only attestation** — `ec` 0.7 `--ignore-rekor` does **not** skip `builtin.attestation.signature_check`, and this claim has no `cosign attest`:
+
+[source,yaml]
+----
+        config:
+          include:
+            - "*"
+          exclude:
+            - attestation_signature_check
+----
+
+Lower `restrict_max_cve_score` below 999, and pin `allowed_registry_prefixes` to the internal registry (`image-registry.openshift-image-registry.svc`).
 
 . In Gitea `.tekton/pipeline.yaml`, add Task `conforma-policy` (cluster resolver, `namespace: lightwell-tasks`) with `runAfter: [cosign-sign-keyless]`. Point `policy-namespace` / `policy-configmap` at *your* copy in `lw-poc-build`, not `lightwell-tasks`. Commit, push, apply the Pipeline.
 
@@ -125,4 +136,4 @@ SLSA L3 / Tekton Chains is a mapping sentence, not this Check. Full table: xref:
 == Key takeaways
 
 * Policy is learner-owned, not a passing default.
-* This claim is not SLSA L3; `skip-att-sig-check` stays true on the ConfigMap (`ec` 0.7: `--ignore-rekor`).
+* This claim is not SLSA L3; exclude `attestation_signature_check` ( `--ignore-rekor` does not skip it).

--- a/content/modules/ROOT/pages/module-15-gitops-admission.adoc
+++ b/content/modules/ROOT/pages/module-15-gitops-admission.adoc
@@ -86,7 +86,20 @@ COSIGN_PASSWORD="" cosign sign --key /home/lab-user/lab-trust/cosign.key \
 
 Keep the `sha256:` prefix. That digest must match Track 5.1.
 
-. Clone the *stage* GitOps remote (`student_gitops_repo_url`). Set `image.digest` to that digest and `replicas: 1`. Commit and push. Do not edit the prod remote. Follow `PROMOTE.md` in that repo if you need the field names.
+. Clone the *stage* GitOps remote (`student_gitops_repo_url`). Set `image.digest` to that digest and `replicas: 1`. Commit and push. Do not edit the prod remote. Follow `PROMOTE.md` in that repo if you need the field names. A fresh clone does not inherit `git config` from the app repo — set author locally (same identity as xref:module-06-bind-base-deps.adoc[3.2]):
+
+[source,bash,role=execute]
+----
+STAGE_GITOPS="$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.student_gitops_repo_url}')"
+: "${STUDENT_USER:=$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.student_username}')}"
+: "${STUDENT_PASS:=$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.student_password}')}"
+rm -rf /tmp/gitops-stage
+hostpath="${STAGE_GITOPS#https://}"; hostpath="${hostpath#http://}"
+git clone "https://${STUDENT_USER}:${STUDENT_PASS}@${hostpath}" /tmp/gitops-stage
+cd /tmp/gitops-stage
+git config user.name student
+git config user.email student@workshop.local
+----
 
 . Wait until Argo Application `lw-poc-staging` is Synced / Healthy (hard-refresh if it still shows `replicas: 0`).
 

--- a/content/modules/ROOT/pages/module-16-prod-gitops.adoc
+++ b/content/modules/ROOT/pages/module-16-prod-gitops.adoc
@@ -65,7 +65,20 @@ COSIGN_PASSWORD="" cosign sign --key /home/lab-user/lab-trust/cosign.key \
   "${DST}"
 ----
 
-Clone `student_prod_gitops_repo_url` (password from `student_password` jsonpath — do not commit it). Replace `sha256:REPLACE_ME_PROD_DIGEST` with that digest; set `replicas: 1`. Commit and push *this* remote only. Do not copy `values.yaml` or `PROMOTE.md` from the stage clone.
+Clone `student_prod_gitops_repo_url` (password from `student_password` jsonpath — do not commit it). Set repo-local `git config user.name` / `user.email` (same as 6.1 — a fresh clone does not inherit the app-repo author). Replace `sha256:REPLACE_ME_PROD_DIGEST` with that digest; set `replicas: 1`. Commit and push *this* remote only. Do not copy `values.yaml` or `PROMOTE.md` from the stage clone.
+
+[source,bash,role=execute]
+----
+PROD_GITOPS="$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.student_prod_gitops_repo_url}')"
+: "${STUDENT_USER:=$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.student_username}')}"
+: "${STUDENT_PASS:=$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.student_password}')}"
+rm -rf /tmp/gitops-prod
+hostpath="${PROD_GITOPS#https://}"; hostpath="${hostpath#http://}"
+git clone "https://${STUDENT_USER}:${STUDENT_PASS}@${hostpath}" /tmp/gitops-prod
+cd /tmp/gitops-prod
+git config user.name student
+git config user.email student@workshop.local
+----
 
 == Check: prod Application sources prod
 


### PR DESCRIPTION
## Summary
- After 4.3, dest Docker Route, ACS Central Route, and RHTAS Routes time out from `lw-poc-build`. This lands in-cluster dest ImageStream retarget, ACS skip-on-timeout + in-cluster Central, TAS `.svc` URLs, and NetworkPolicy **pod** ports (stackrox 8443, TAS 8080/5555/3000, TPA 8080).
- Syft persist uses `oc delete` + `oc create` (no `apply` last-applied cap). Prefetch listing/`check-09` require `COPY .m2-offline`. Conforma listing/`check-13` exclude only `attestation_signature_check`. 6.1/6.2 clones set repo-local git author.
- Issues 90–97 stay open with `needs-next-cluster` until a fresh provision confirms the student path. `cluster-g9nhh` already completed the walk with workarounds.

## Test plan
- [ ] Next provisioned claim: 3.2 dest Route FROM still passes Check-06; 4.1 imports dest IS and Check-08 requires internal registry FROM
- [ ] 4.4 PipelineRun: ACS skip or in-cluster Central; syft `runAfter` build; persist ConfigMap created; known-bad Ctrl-C after first docker.io timeout
- [ ] 5.1 signs with `trusted-artifact-signer.svc`; 5.2 pass path with attestation exclude; 6.1/6.2 git commit with listing `git config`


Made with [Cursor](https://cursor.com)