### PR TITLE
Fix 5.2 Conforma pass path without --ignore-rekor (#96)

### DIFF
--- a/automation/gitops/components/pipelines/templates/conforma-policy-docs.yaml
+++ b/automation/gitops/components/pipelines/templates/conforma-policy-docs.yaml
@@ -27,14 +27,18 @@ data:
     seed (skip-image-sig-check=true, CVE 999, identity .*, exclude *). Argo
     reverts edits to that object.
 
-    Copy it into {{ .Values.conformaPolicy.labNamespace }}, turn skip flags
-    off, set identity to the RHTAS app signer (not a wildcard, not the
-    Hummingbird placeholder), drop the exclude-all, lower restrict_max_cve_score,
-    and pin allowed_registry_prefixes to the internal registry.
+    Copy it into {{ .Values.conformaPolicy.labNamespace }}, turn
+    skip-image-sig-check off, leave skip-att-sig-check true (no Chains /
+    no cosign attest), set identity to the RHTAS app signer (not a wildcard,
+    not the Hummingbird placeholder), drop the exclude-all, lower
+    restrict_max_cve_score, and pin allowed_registry_prefixes to the
+    internal registry. Do not pass --ignore-rekor.
 
     Wire the Task in Gitea .tekton/pipeline.yaml AFTER cosign-sign-keyless.
-    Point policy-namespace / policy-configmap at YOUR copy. Unsigned FROM
-    must fail; the learner-built signed image must pass.
+    Point policy-namespace / policy-configmap at YOUR copy. Pass in-cluster
+    tuf-url and rekor-url (*.trusted-artifact-signer.svc). Unsigned FROM
+    must fail; the learner-built signed image must pass aside from the
+    attestation builtin.
 
     Do not copy example-pipeline-snippet.yaml or example-policy.yaml.
     No quay.io / github.com policy fetch. Image build stays OpenShift BuildConfig.

--- a/automation/gitops/components/pipelines/templates/conforma-policy-task.yaml
+++ b/automation/gitops/components/pipelines/templates/conforma-policy-task.yaml
@@ -33,6 +33,11 @@ spec:
     - name: rekor-url
       type: string
       default: ""
+      description: In-cluster Rekor (http://rekor-server.trusted-artifact-signer.svc). Routes time out after 4.3.
+    - name: tuf-url
+      type: string
+      default: ""
+      description: In-cluster TUF (http://tuf.trusted-artifact-signer.svc). Needed so Fulcio certs verify.
   results:
     - name: verify-status
       type: string
@@ -61,6 +66,28 @@ spec:
           --to=/policy \
           --confirm
         ls -l /policy
+    - name: tuf-init
+      computeResources: {}
+      image: {{ .Values.conformaPolicy.cosignImage | quote }}
+      env:
+        - name: TUF_URL
+          value: $(params.tuf-url)
+        - name: HOME
+          value: /tmp
+      volumeMounts:
+        - name: policy-files
+          mountPath: /policy
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [[ -z "${TUF_URL}" ]]; then
+          echo "tuf-url empty — skip cosign initialize (pipeline must pass in-cluster TUF after 4.3)"
+          exit 0
+        fi
+        echo "cosign initialize --mirror=${TUF_URL}"
+        cosign initialize --mirror="${TUF_URL}" --root="${TUF_URL}/root.json"
+        mkdir -p /policy/sigstore
+        cp -a /tmp/.sigstore/. /policy/sigstore/
     - name: validate
       computeResources: {}
       image: {{ .Values.conformaPolicy.ecImage | quote }}
@@ -73,6 +100,8 @@ spec:
           value: {{ .Values.conformaPolicy.namespace | quote }}
         - name: REKOR_URL
           value: $(params.rekor-url)
+        - name: TUF_URL
+          value: $(params.tuf-url)
         - name: HOME
           value: /tmp
         - name: COSIGN_INSECURE
@@ -108,19 +137,27 @@ spec:
 
         mkdir -p /tmp/ec
         cp /policy/policy.yaml /policy/rules.rego /policy/data.yaml /tmp/ec/
+        if [[ -d /policy/sigstore ]]; then
+          mkdir -p /tmp/.sigstore
+          cp -a /policy/sigstore/. /tmp/.sigstore/
+        fi
 
         if [[ -f /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ]]; then
           export SSL_CERT_FILE=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
         fi
 
+        # ec 0.7.197 has no --skip-att-sig-check. Do not pass --ignore-rekor: Fulcio
+        # certs expire and need Rekor timestamps. Judge skip-att by dropping the
+        # attestation builtin from the text report (this claim has no cosign attest).
         CMD=(
           ec validate image
           --image="${IMAGE}"
           --policy=/tmp/ec/policy.yaml
-          --strict=true
+          --strict=false
           --show-successes
           --info
           --output=text
+          --output=text=/tmp/ec-out.txt
           --certificate-identity-regexp="${IDENTITY}"
           --certificate-oidc-issuer-regexp="${ISSUER}"
           --extra-rule-data="certificate_identity_regexp=${IDENTITY}"
@@ -129,8 +166,8 @@ spec:
         if [[ "${SKIP_IMG}" == "true" ]]; then
           echo "skip-image-sig-check=true (seed). ec 0.7 has no --skip-image-sig-check; not passing it."
         fi
-        if [[ "${SKIP_ATT}" == "true" || "${IGNORE_REKOR}" == "true" ]]; then
-          CMD+=(--ignore-rekor)
+        if [[ "${IGNORE_REKOR}" == "true" ]]; then
+          echo "WARN: ignore-rekor=true on the ConfigMap is ignored — it breaks Fulcio timestamp verify."
         fi
         if [[ -n "${REKOR_URL}" ]]; then
           CMD+=(--rekor-url="${REKOR_URL}")
@@ -139,7 +176,7 @@ spec:
         echo "=== conforma-policy (ec validate image) ==="
         echo "image=${IMAGE}"
         echo "policy-namespace=${POLICY_NAMESPACE}"
-        echo "skip-image-sig-check=${SKIP_IMG} skip-att-sig-check=${SKIP_ATT} (ec 0.7: --ignore-rekor)"
+        echo "skip-image-sig-check=${SKIP_IMG} skip-att-sig-check=${SKIP_ATT} tuf=${TUF_URL}"
         echo "identity=${IDENTITY}"
 
         if [[ "${POLICY_NAMESPACE}" == "${SEED_NAMESPACE}" ]]; then
@@ -147,7 +184,23 @@ spec:
           echo "Copy it to the lab namespace and pass policy-namespace / policy-configmap."
         fi
 
-        "${CMD[@]}" || fail "ec validate image failed (unsigned FROM or policy still too weak/wrong)"
+        "${CMD[@]}" || true
+        [[ -f /tmp/ec-out.txt ]] || fail "ec wrote no text report"
+        cat /tmp/ec-out.txt
+        violations="$(grep '\[Violation\]' /tmp/ec-out.txt || true)"
+        leftover="$(printf '%s\n' "${violations}" | grep -v 'builtin.attestation.signature_check' | grep '[^[:space:]]' || true)"
+        if [[ "${SKIP_ATT}" == "true" ]]; then
+          if [[ -n "${leftover}" ]]; then
+            fail "ec still failing besides attestation builtin: ${leftover}"
+          fi
+          if [[ "${SKIP_IMG}" != "true" ]] && printf '%s\n' "${violations}" | grep -q 'builtin.image.signature_check'; then
+            fail "image signature check failed (unsigned image, or missing TUF/Rekor params)"
+          fi
+        else
+          if [[ -n "${violations}" ]]; then
+            fail "ec validate image failed (unsigned FROM or policy still too weak/wrong)"
+          fi
+        fi
         echo -n "passed" > "${STATUS}"
         echo "Conforma policy passed"
 {{- end }}

--- a/automation/gitops/components/pipelines/values.yaml
+++ b/automation/gitops/components/pipelines/values.yaml
@@ -31,14 +31,16 @@ conformaPolicy:
   configMapName: conforma-policy
   labNamespace: lw-poc-build
   # RHTAS 1.3 ships ec as 0.7 (not :1.3.0 — that tag does not exist). Pull uses the PipelineRun SA (lab ns).
+  # v0.7.197 has no --skip-att-sig-check; --ignore-rekor breaks Fulcio cert timestamps.
   ecImage: registry.redhat.io/rhtas/ec-rhel9:0.7
   oseCliImage: registry.redhat.io/openshift4/ose-cli:latest
+  cosignImage: registry.redhat.io/rhtas/cosign-rhel9:1.3.0
   # Seed is too permissive. Learner copies the ConfigMap to the lab ns and tightens.
   skipImageSigCheck: "true"
   skipAttSigCheck: "true"
   certificateIdentityRegexp: ".*"
   certificateOidcIssuerRegexp: ".*"
-  ignoreRekor: "true"
+  ignoreRekor: "false"
   restrictMaxCveScore: 999
 
 # V2-23: Maven prefetch Task (Konflux Hermeto analogue). Seeded pipeline does NOT reference it.

--- a/automation/gitops/components/validate-jobs/files/check-13.sh
+++ b/automation/gitops/components/validate-jobs/files/check-13.sh
@@ -7,6 +7,8 @@ ns="$(build_ns)"
 gitea_repo_ok "$org" "$repo"
 skip="$(cm_get "$ns" conforma-policy skip-image-sig-check)"
 [[ "$skip" == "false" ]] || fail "ConfigMap ${ns}/conforma-policy skip-image-sig-check must be false (copy and tighten; do not edit lightwell-tasks)."
+skip_att="$(cm_get "$ns" conforma-policy skip-att-sig-check)"
+[[ "$skip_att" == "true" ]] || fail "ConfigMap ${ns}/conforma-policy skip-att-sig-check must stay true (no Chains / no cosign attest on this claim)."
 ident="$(cm_get "$ns" conforma-policy certificate-identity-regexp)"
 [[ -n "$ident" ]] || fail "ConfigMap ${ns}/conforma-policy is missing certificate-identity-regexp."
 [[ "$ident" != ".*" ]] || fail "certificate-identity-regexp is still '.*'. Use the pipeline SA identity."
@@ -14,14 +16,21 @@ deny_contains "${ns}/conforma-policy identity" "$ident" "example.invalid"
 cve="$(cm_get "$ns" conforma-policy data.yaml)"
 deny_contains "${ns}/conforma-policy data.yaml" "$cve" "restrict_max_cve_score: 999"
 policy_yaml="$(cm_get "$ns" conforma-policy policy.yaml)"
-require_contains "${ns}/conforma-policy policy.yaml" "$policy_yaml" "attestation_signature_check"
 deny_contains "${ns}/conforma-policy policy.yaml still excludes everything" "$policy_yaml" 'exclude:
             - "*"'
 git_pl="$(gitea_raw "$org" "$repo" .tekton/pipeline.yaml)"
 task_before "$git_pl" cosign-sign-keyless conforma-policy "${org}/${repo} .tekton/pipeline.yaml"
+printf '%s\n' "$git_pl" | grep -A40 'name: conforma-policy' | grep -q 'name: tuf-url' \
+  || fail "conforma-policy in git must pass tuf-url (in-cluster TUF after 4.3)."
+printf '%s\n' "$git_pl" | grep -A40 'name: conforma-policy' | grep -q 'name: rekor-url' \
+  || fail "conforma-policy in git must pass rekor-url (in-cluster Rekor after 4.3)."
 live="$(pipeline_yaml "$ns" spring-boot-lw-poc-build-sign)"
 task_before "$live" cosign-sign-keyless conforma-policy "Pipeline ${ns}/spring-boot-lw-poc-build-sign"
 printf '%s\n' "$live" | grep -A3 'policy-namespace' | grep -q "$ns" \
   || fail "conforma-policy policy-namespace must be ${ns} (the tightened copy), not lightwell-tasks."
+printf '%s\n' "$live" | grep -A40 'name: conforma-policy' | grep -q 'name: tuf-url' \
+  || fail "live Pipeline conforma-policy must pass tuf-url (in-cluster TUF)."
+printf '%s\n' "$live" | grep -A40 'name: conforma-policy' | grep -q 'name: rekor-url' \
+  || fail "live Pipeline conforma-policy must pass rekor-url (in-cluster Rekor)."
 report_require_token policy_owner learner-copy
 pass "Conforma copy in ${ns} is tightened and runs after cosign-sign-keyless."

--- a/content/modules/ROOT/pages/appendix-consultant-delivery.adoc
+++ b/content/modules/ROOT/pages/appendix-consultant-delivery.adoc
@@ -131,7 +131,7 @@ You did *not* click every engagement activity. Use the *Playbook* / *Not on this
 
 |SLSA L3 / Tekton Chains
 |Callout + Conforma
-|5.2 scores tightened Conforma; `skip-att-sig-check` stays true (`ec` 0.7: `--ignore-rekor`). Chains is mapping (xref:appendix-konflux-mapping.adoc[Konflux mapping]), not SLSA L3 on this claim.
+|5.2 scores tightened Conforma; `skip-att-sig-check` stays true (`ec` 0.7 has no skip flag — ignore only the attestation builtin, do not use `--ignore-rekor`). Chains is mapping (xref:appendix-konflux-mapping.adoc[Konflux mapping]), not SLSA L3 on this claim.
 
 |Key-based / disconnected verify
 |Scored

--- a/content/modules/ROOT/pages/appendix-konflux-mapping.adoc
+++ b/content/modules/ROOT/pages/appendix-konflux-mapping.adoc
@@ -47,7 +47,7 @@ The activity map (what you clicked vs playbook) is xref:appendix-consultant-deli
 |xref:module-18-vex-acs.adoc[7.2] (scored; must not stay skipped)
 
 |Tekton Chains
-|RHTAS *keyless* cosign Task `cosign-sign-keyless` (xref:module-12-sign-keyless.adoc[5.1]). There is *no* Tekton Chains on this claim and no SLSA L3. xref:module-13-attest-conforma.adoc[5.2] leaves `skip-att-sig-check=true` (mapped to `ec --ignore-rekor`).
+|RHTAS *keyless* cosign Task `cosign-sign-keyless` (xref:module-12-sign-keyless.adoc[5.1]). There is *no* Tekton Chains on this claim and no SLSA L3. xref:module-13-attest-conforma.adoc[5.2] leaves `skip-att-sig-check=true` (ignore `builtin.attestation.signature_check` in the `ec` report; do not use `--ignore-rekor`).
 |5.1 scored (keyless). Chains itself is mapping only.
 
 |Conforma

--- a/content/modules/ROOT/pages/module-13-attest-conforma.adoc
+++ b/content/modules/ROOT/pages/module-13-attest-conforma.adoc
@@ -5,7 +5,7 @@
 
 Konflux *Conforma* (Enterprise Contract) is an `ec validate` policy on the image after sign. This claim maps that control to Task `conforma-policy` in namespace `lightwell-tasks`. The Task is *not* in the seeded pipeline. The seeded ConfigMap is *too permissive* (signature checks skipped, identity `.*`, CVE 999). Argo reverts edits to that object — copy it to `lw-poc-build` and tighten the *copy*.
 
-This Check is fail-then-pass on *signatures + policy*, not SLSA L3. There is no Tekton Chains on this claim and no `cosign attest` step. Leave `skip-att-sig-check=true` on the ConfigMap (the Task maps that to `--ignore-rekor`; `ec` 0.7 has no `--skip-att-sig-check`). Mapping: Konflux Conforma → this Task; Chains / in-toto → callout. Full table: xref:appendix-konflux-mapping.adoc[Appendix: Konflux mapping].
+This Check is fail-then-pass on *signatures + policy*, not SLSA L3. There is no Tekton Chains on this claim and no `cosign attest` step. Leave `skip-att-sig-check=true` on the ConfigMap. Showroom `ec` is 0.7 (`ec-rhel9:0.7`): it has no `--skip-att-sig-check`, and `--ignore-rekor` breaks Fulcio timestamps on the *pass* path. The listing and Task ignore only `builtin.attestation.signature_check` in the report. Mapping: Konflux Conforma → this Task; Chains / in-toto → callout. Full table: xref:appendix-konflux-mapping.adoc[Appendix: Konflux mapping].
 
 == Learning objectives
 
@@ -66,54 +66,55 @@ oc -n lightwell-tasks get configmap conforma-policy -o yaml \
   | oc apply -f -
 ----
 
-. On the *copy*, set `skip-image-sig-check` to `false`. Leave `skip-att-sig-check` `true` (no Chains attestation on this claim). Set `certificate-identity-regexp` to the same pipeline SA regexp you used in 5.1 (not `.*`, not a Hummingbird placeholder). Set the OIDC issuer regexp to `https://kubernetes.default.svc`. In `policy.yaml` / `data.yaml`, drop `exclude: *`, then **exclude only attestation** — `ec` 0.7 `--ignore-rekor` does **not** skip `builtin.attestation.signature_check`, and this claim has no `cosign attest`:
+. On the *copy*, set `skip-image-sig-check` to `false`. Leave `skip-att-sig-check` `true` (no Chains / no `cosign attest` on this claim). Set `certificate-identity-regexp` to the same pipeline SA regexp you used in 5.1 (not `.*`, not a Hummingbird placeholder). Set the OIDC issuer regexp to `https://kubernetes.default.svc`. In `policy.yaml` / `data.yaml`, drop `exclude: *`. Do *not* add an `exclude:` for `attestation_signature_check` — `ec` 0.7 builtins ignore that list. Lower `restrict_max_cve_score` below 999, and pin `allowed_registry_prefixes` to the internal registry (`image-registry.openshift-image-registry.svc`).
 
-[source,yaml]
-----
-        config:
-          include:
-            - "*"
-          exclude:
-            - attestation_signature_check
-----
-
-Lower `restrict_max_cve_score` below 999, and pin `allowed_registry_prefixes` to the internal registry (`image-registry.openshift-image-registry.svc`).
-
-. In Gitea `.tekton/pipeline.yaml`, add Task `conforma-policy` (cluster resolver, `namespace: lightwell-tasks`) with `runAfter: [cosign-sign-keyless]`. Point `policy-namespace` / `policy-configmap` at *your* copy in `lw-poc-build`, not `lightwell-tasks`. Commit, push, apply the Pipeline.
+. In Gitea `.tekton/pipeline.yaml`, add Task `conforma-policy` (cluster resolver, `namespace: lightwell-tasks`) with `runAfter: [cosign-sign-keyless]`. Point `policy-namespace` / `policy-configmap` at *your* copy in `lw-poc-build`, not `lightwell-tasks`. Pass `tuf-url: $(params.cosign-tuf-url)` and `rekor-url: $(params.cosign-rekor-url)` (in-cluster `*.trusted-artifact-signer.svc` from 4.3 / 5.1 — not HTTPS Route hints). Commit, push, apply the Pipeline.
 
 == Check: fail on the builder; pass on the signed app
 
 Fail path is the in-cluster ImageStream `openjdk-21-builder` you imported in xref:module-08-forbid-list.adoc[4.1] — it is *not* signed with the RHTAS pipeline SA. It can pull (internal registry is allowed). Pass path is the 5.1 app digest. Do not use `docker.io/library/java:latest` (worked example; hermetic egress also blocks it from the build namespace).
 
-`ec` is on Showroom `PATH` (do not curl `github.com`). Extract *your* copy, then validate twice:
+`ec` is on Showroom `PATH` (do not curl `github.com`). Initialize TUF and log in to the internal registry the same way as xref:module-12-sign-keyless.adoc[5.1]. Do *not* pass `--ignore-rekor` (Fulcio certs need Rekor timestamps) and do *not* pass `--skip-att-sig-check` (unknown on `ec` 0.7). `--strict=false` writes a report even when the attestation builtin fails; judge the files, not the exit code.
 
 [source,bash,role=execute]
 ----
 BUILD_NS="$(oc -n gitea get configmap demo-userinfo-gitea -o jsonpath='{.data.student_build_namespace}')"
+TUF="$(oc -n trusted-artifact-signer get configmap demo-userinfo-rhtas -o jsonpath='{.data.tuf_url_hint}')"
 REKOR="$(oc -n trusted-artifact-signer get configmap demo-userinfo-rhtas -o jsonpath='{.data.rekor_url_hint}')"
 mkdir -p /tmp/ec /tmp/lab-home
 export HOME=/tmp/lab-home
 export SSL_CERT_FILE=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+cosign initialize --mirror="${TUF}" --root="${TUF}/root.json"
+cosign login -u unused -p "$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  image-registry.openshift-image-registry.svc:5000
 oc -n "${BUILD_NS}" extract configmap/conforma-policy --to=/tmp/ec --confirm
 FAIL_IMG="image-registry.openshift-image-registry.svc:5000/${BUILD_NS}/openjdk-21-builder:latest"
 PASS_IMG="image-registry.openshift-image-registry.svc:5000/${BUILD_NS}/spring-boot-lw-poc:latest"
 IDENTITY="$(tr -d '[:space:]' < /tmp/ec/certificate-identity-regexp)"
 ISSUER="$(tr -d '[:space:]' < /tmp/ec/certificate-oidc-issuer-regexp)"
-# Expect non-zero:
-ec validate image --image="${FAIL_IMG}" --policy=/tmp/ec/policy.yaml --strict=true \
+# Fail path: unsigned builder must report builtin.image.signature_check
+ec validate image --image="${FAIL_IMG}" --policy=/tmp/ec/policy.yaml --strict=false \
+  --show-successes --info --output=text=/tmp/ec-fail.txt \
   --certificate-identity-regexp="${IDENTITY}" \
   --certificate-oidc-issuer-regexp="${ISSUER}" \
-  --ignore-rekor --rekor-url="${REKOR}" && echo 'FAIL PATH UNEXPECTEDLY PASSED'
-# Expect zero:
-ec validate image --image="${PASS_IMG}" --policy=/tmp/ec/policy.yaml --strict=true \
+  --rekor-url="${REKOR}" || true
+grep '\[Violation\]' /tmp/ec-fail.txt | grep -q 'builtin.image.signature_check' \
+  || { echo 'FAIL PATH UNEXPECTEDLY PASSED'; cat /tmp/ec-fail.txt; exit 1; }
+# Pass path: ignore only the attestation builtin (no cosign attest on this claim)
+ec validate image --image="${PASS_IMG}" --policy=/tmp/ec/policy.yaml --strict=false \
+  --show-successes --info --output=text=/tmp/ec-pass.txt \
   --certificate-identity-regexp="${IDENTITY}" \
   --certificate-oidc-issuer-regexp="${ISSUER}" \
-  --ignore-rekor --rekor-url="${REKOR}"
+  --rekor-url="${REKOR}" || true
+grep '\[Violation\]' /tmp/ec-pass.txt | grep -q 'builtin.image.signature_check' \
+  && { echo 'PASS PATH: image signature still failing'; cat /tmp/ec-pass.txt; exit 1; }
+leftover="$(grep '\[Violation\]' /tmp/ec-pass.txt | grep -v 'builtin.attestation.signature_check' || true)"
+[[ -z "${leftover}" ]] || { echo "PASS PATH leftover: ${leftover}"; cat /tmp/ec-pass.txt; exit 1; }
 oc -n "${BUILD_NS}" get pipeline spring-boot-lw-poc-build-sign -o yaml \
-  | grep -A25 'name: conforma-policy' | head -30
+  | grep -A30 'name: conforma-policy' | head -40
 ----
 
-Pass when the builder validate fails, the app digest passes, the live Pipeline includes `conforma-policy` after `cosign-sign-keyless`, and `policy-namespace` is `lw-poc-build`.
+Pass when the builder report has `builtin.image.signature_check` as a `[Violation]`, the signed app leftover `[Violation]` lines are empty after dropping `builtin.attestation.signature_check`, the live Pipeline includes `conforma-policy` after `cosign-sign-keyless` with in-cluster `tuf-url` / `rekor-url`, and `policy-namespace` is `lw-poc-build`.
 
 // VISUAL: https://github.com/NA-FSI-Services/lightwell-tssc-workshop/issues/68
 image::FIXME-conforma-fail-then-pass.png[Conforma fail on openjdk-21-builder then pass on signed app digest,width=700,link=self,window=blank]
@@ -136,4 +137,4 @@ SLSA L3 / Tekton Chains is a mapping sentence, not this Check. Full table: xref:
 == Key takeaways
 
 * Policy is learner-owned, not a passing default.
-* This claim is not SLSA L3; exclude `attestation_signature_check` ( `--ignore-rekor` does not skip it).
+* This claim is not SLSA L3; leave `skip-att-sig-check=true` and ignore `builtin.attestation.signature_check` in the `ec` report (do not use `--ignore-rekor`).


### PR DESCRIPTION
## Summary
- 5.2 listing and Task `conforma-policy` no longer pass `--ignore-rekor` (it breaks Fulcio timestamps on signed images).
- `ec` 0.7 has no `--skip-att-sig-check`; ignore only `builtin.attestation.signature_check` in the text report after TUF init.
- Check-13 grades `skip-att-sig-check=true` plus in-cluster `tuf-url` / `rekor-url` instead of a `policy.yaml` exclude that builtins ignore.

## Test plan
- [ ] Next claim: 5.2 listing fail-then-pass (`builtin.image.signature_check` on unsigned builder; leftover empty on signed app after dropping attestation).
- [ ] Next claim: Task `conforma-policy` Succeeded when wired with in-cluster TUF/Rekor after sign.
- [ ] Do **not** close [#96](https://github.com/NA-FSI-Services/lightwell-tssc-workshop/issues/96) until that claim confirms (Showroom HTML is baked at provision).


Made with [Cursor](https://cursor.com)