### PR TITLE
ci: add GitHub Pages workflow for Showroom lab guide preview

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,50 @@
+name: github pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "README.adoc"
+      - "README.md"
+      - ".gitignore"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: configure pages
+        uses: actions/configure-pages@v5
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.13.1
+      - name: install antora
+        run: npm install --global @antora/cli@3.1 @antora/site-generator@3.1
+      - name: antora generate
+        run: antora generate site.yml --stacktrace
+      - name: upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: www
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: deploy github pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Add `.github/workflows/gh-pages.yml` to build the Antora site and deploy to GitHub Pages
- Lab guide preview will be available at: https://rhpds.github.io/lightwell-tssc-workshop
- Uses `site.yml` as the Antora playbook (matches existing repo config)

## Why

The AgnosticV catalog `description.adoc` links to the GitHub Pages preview but no workflow existed to build and deploy it.

## Test plan

- [ ] Merge this PR and verify the workflow runs successfully
- [ ] Confirm https://rhpds.github.io/lightwell-tssc-workshop loads the lab guide
- [ ] Verify GitHub Pages is configured to deploy from the `github-pages` environment