### PR TITLE
fix: update gh-pages workflow to match RHDP standard

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,11 +6,9 @@ on:
     branches: [main]
     paths-ignore:
       - "README.adoc"
-      - "README.md"
       - ".gitignore"
 
 permissions:
-  contents: read
   pages: write
   id-token: write
 
@@ -23,19 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: configure pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.13.1
+          node-version: 22
       - name: install antora
-        run: npm install --global @antora/cli@3.1 @antora/site-generator@3.1
+        run: npm install --global @antora/cli@3.1 @antora/site-generator@3.1 @sntke/antora-mermaid-extension
+      - name: patch antora-mermaid-extension
+        run: >-
+          sed -i
+          's/this\.getLogger/context.getLogger/'
+          "$(npm root -g)/@sntke/antora-mermaid-extension/lib/extension.js"
       - name: antora generate
         run: antora generate site.yml --stacktrace
       - name: upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: www
   deploy:
@@ -47,4 +50,4 @@ jobs:
     steps:
     - name: deploy github pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- Bump actions to v5/v6 (checkout, configure-pages, setup-node, upload-pages-artifact, deploy-pages)
- Use Node 22 instead of 20.13.1
- Add antora-mermaid-extension with getLogger patch (standard RHDP pattern)
- Remove unnecessary `contents: read` permission

Follows the standard from rhpds/lb2298-ibm-fusion.

## Test plan

- [ ] Verify workflow runs successfully after merge
- [ ] Confirm https://rhpds.github.io/lightwell-tssc-workshop loads correctly